### PR TITLE
feat: add Browserless MCP server to official catalog

### DIFF
--- a/public/servers/official.json
+++ b/public/servers/official.json
@@ -34,6 +34,25 @@
     "homepage": "https://github.com/microsoft/semanticworkbench/tree/HEAD/mcp-servers/mcp-server-bing-search"
   },
   {
+    "name": "Browserless",
+    "key": "browserless",
+    "description": "Headless browser automation for AI agents — navigate, scrape, fill forms, screenshot, search the web, and run multi-step browser research via a stateful agent loop. 9 tools backed by the Browserless cloud.",
+    "command": "npx",
+    "args": [
+      "-y",
+      "mcp-remote",
+      "https://mcp.browserless.io/mcp",
+      "--transport",
+      "http-only",
+      "--header",
+      "Authorization:${AUTH_HEADER}"
+    ],
+    "env": {
+      "AUTH_HEADER": "{{apiToken@string::Bearer <your token from https://www.browserless.io/signup/email>}}"
+    },
+    "homepage": "https://www.browserless.io/"
+  },
+  {
     "name": "Cloudflare",
     "key": "cloudflare",
     "description": "Manage KV stores, R2 storage, D1 databases, and Workers deployments.",


### PR DESCRIPTION
## Summary

Adds [Browserless](https://www.browserless.io/) to `public/servers/official.json`.

Browserless is a hosted headless-browser-automation platform. The MCP server is hosted at `https://mcp.browserless.io/mcp` (streamable HTTP, MCP 2025-03-26) and exposes 9 tools: a stateful `browserless_agent` loop plus `smartscraper`, `search`, `function`, `download`, `export`, `map`, `performance`, and `crawl`.

## How it connects

The entry uses [`mcp-remote`](https://github.com/geelen/mcp-remote) as the stdio→streamable-HTTP shim (same approach Claude Desktop and Cursor use for remote MCP servers). Users provide a Bearer token from https://www.browserless.io/signup/email; no local install or extra package required.