### PR TITLE
Add VedaVisor Vedic Astrology MCP

### DIFF
--- a/public/servers/community.json
+++ b/public/servers/community.json
@@ -15,8 +15,17 @@
     "name": "VedaVisor Vedic Astrology MCP",
     "key": "vedavisor-vedic-astrology-mcp",
     "description": "Hosted Vedic astrology MCP server with 22 tools for birth charts, dashas, yogas, compatibility, panchanga, muhurta, prashna, and chart-aware Cosmic Advisor interpretation.",
-    "command": "remote",
-    "args": ["https://mcp.vedavisor.com/mcp"],
+    "command": "npx",
+    "args": [
+      "-y",
+      "mcp-remote",
+      "https://mcp.vedavisor.com/mcp",
+      "--header",
+      "Authorization: Bearer ${VEDAVISOR_MCP_API_KEY}"
+    ],
+    "env": {
+      "VEDAVISOR_MCP_API_KEY": "apiKey@string::Your VedaVisor MCP API key"
+    },
     "homepage": "https://github.com/dchhill/vedavisor-vedic-astrology-mcp"
   }
 ]

--- a/public/servers/community.json
+++ b/public/servers/community.json
@@ -10,5 +10,13 @@
       "NOTION_TOKEN": "token@string::Your-Notion-Token"
     },
     "homepage": "https://github.com/camel-ai/Camel-toolkits-mcp"
+  },
+  {
+    "name": "VedaVisor Vedic Astrology MCP",
+    "key": "vedavisor-vedic-astrology-mcp",
+    "description": "Hosted Vedic astrology MCP server with 22 tools for birth charts, dashas, yogas, compatibility, panchanga, muhurta, prashna, and chart-aware Cosmic Advisor interpretation.",
+    "command": "remote",
+    "args": ["https://mcp.vedavisor.com/mcp"],
+    "homepage": "https://github.com/dchhill/vedavisor-vedic-astrology-mcp"
   }
 ]


### PR DESCRIPTION
Adds VedaVisor Vedic Astrology MCP to the community server directory.\n\nVedaVisor is a hosted Streamable HTTP MCP server for Vedic astrology with 22 tools for birth charts, dashas, yogas, compatibility, panchanga, muhurta, prashna, and chart-aware Cosmic Advisor interpretation.\n\nPublic listing repo: https://github.com/dchhill/vedavisor-vedic-astrology-mcp\nMCP endpoint: https://mcp.vedavisor.com/mcp